### PR TITLE
Small cleanup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use anyhow::Result;
-use image::imageops;
+use image::{imageops, GenericImageView};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
@@ -83,19 +83,7 @@ impl PrefHolder {
 	) -> Result<(HashMap<u8, ImageVecMap>, ImageVecMap)> {
 		let img = image::load(input, image::ImageFormat::Png)?;
 
-		let img_dimensions = match &img {
-			image::DynamicImage::ImageLuma8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageLumaA8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageRgb8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageRgba8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageBgr8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageBgra8(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageLuma16(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageLumaA16(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageRgb16(inner_img) => inner_img.dimensions(),
-			image::DynamicImage::ImageRgba16(inner_img) => inner_img.dimensions(),
-		};
-
+		let img_dimensions = img.dimensions();
 		let width_in_frames = img_dimensions.0 / self.icon_size_x;
 		let height_in_frames = img_dimensions.1 / self.icon_size_y;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,5 @@
 use super::glob;
 use dmi::error;
-use std::collections::HashSet;
 
 pub fn smooth_dir_to_combination_key(smooth_dirs: u8, is_diagonal: bool) -> u8 {
 	let mut combination_key = glob::NONE;
@@ -185,16 +184,4 @@ pub fn trim_path_before_last_slash(mut text: String) -> String {
 	};
 	text.drain(..slash_offset);
 	text
-}
-
-pub fn hash_set_lazy_add(hash: Option<HashSet<u8>>, value: u8) -> Option<HashSet<u8>> {
-	let new_hash;
-	if hash == None {
-		new_hash = Some(HashSet::new());
-	} else {
-		new_hash = hash;
-	};
-	let mut unwrapped = new_hash.unwrap();
-	unwrapped.insert(value);
-	Some(unwrapped)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,10 @@ fn main() {
 		return;
 	}
 
-	for image_path_string in args.iter().enumerate() {
-		let icons_built = image_path_string.0;
-		let image_path_string = image_path_string.1;
-
+	for (icons_built, image_path_string) in args.iter().enumerate() {
 		let path = Path::new(&image_path_string);
-		let mut file;
-		match File::open(&path) {
-			Ok(f) => file = f,
+		let mut file = match File::open(&path) {
+			Ok(f) => f,
 			Err(e) => {
 				println!("Wrong file path: {:#?}", e);
 				dont_disappear::any_key_to_continue::default();
@@ -88,9 +84,7 @@ fn build_icons(
 	prefs: &config::PrefHolder,
 	icons_built: usize,
 ) -> Result<bool> {
-	let corners_and_prefabs = prefs.build_corners_and_prefabs(input, &*file_string_path)?;
-	let corners = corners_and_prefabs.0;
-	let mounted_prefabs = corners_and_prefabs.1;
+	let (corners, mounted_prefabs) = prefs.build_corners_and_prefabs(input, &*file_string_path)?;
 
 	let possible_icon_states = prepare_icon_states(prefs.is_diagonal);
 
@@ -107,32 +101,30 @@ fn build_icons(
 		icon_directions = vec![glob::BYOND_SOUTH];
 	};
 
-	let output_name;
-	match &prefs.output_name {
+	let output_name = match &prefs.output_name {
 		Some(thing) => {
 			if icons_built == 0 {
-				output_name = thing.to_string();
+				thing.to_string()
 			} else {
-				output_name = format!("{}({})", &thing, icons_built + 1)
-			};
+				format!("{}({})", &thing, icons_built + 1)
+			}
 		}
 		None => {
 			if file_string_path.is_empty() {
 				if icons_built == 0 {
-					output_name = "output".to_string()
+					"output".to_string()
 				} else {
-					output_name = format!("output({})", icons_built + 1)
-				};
+					format!("output({})", icons_built + 1)
+				}
 			} else {
-				output_name = format!(
+				format!(
 					"{}-output",
 					helpers::trim_path_before_last_slash(file_string_path)
-				);
-			};
+				)
+			}
 		}
 	};
-	let icon_state_name;
-	icon_state_name = match &prefs.base_icon_state {
+	let icon_state_name = match &prefs.base_icon_state {
 		Some(thing) => thing.clone(),
 		None => "icon".to_string(),
 	};


### PR DESCRIPTION
* Makes use of the `GenericImageView` trait for the `dimensions()` method.
* Removes an unused helper function that could be better written if needed.
* Reduces code a little with patterns I didn't know Rust had when I wrote them.